### PR TITLE
Block Devices Mappings Tag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ application.yml
 *.hprof
 README.html
 *~
+.classpath
+.project
+.settings/
+bin/

--- a/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
+++ b/clouddriver-aws/src/test/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandlerUnitSpec.groovy
@@ -174,6 +174,31 @@ class BasicAmazonDeployHandlerUnitSpec extends Specification {
     actualClassicLinkVpcId == null
   }
 
+  void "should append spinnaker:deploymentMetadata tag indicating deviceMapping"() {
+    setup:
+    def description = new BasicAmazonDeployDescription(
+      amiName: "ami-12345",
+      availabilityZones: ["us-west-1": []],
+      credentials: TestCredential.named('baz'),
+      subnetType: "internal",
+      useAmiBlockDeviceMappings: testUseAmiBlockDeviceMappings,
+      blockDevices: testBlockDevices
+    )
+
+    when:
+    handler.handle(description, [])
+
+    then:
+    description.tags.get("spinnaker:deploymentMetadata") == expectedDeploymentMetadata
+
+    where:
+    testUseAmiBlockDeviceMappings | testBlockDevices                                           | expectedDeploymentMetadata
+    true                          | null                                                       | "{\"deviceMapping\":\"ami\"}"     // Prefer AMI Block Device Mappings set, set deviceMapping as 'ami'
+    true                          | [new AmazonBlockDevice(deviceName: "/dev/sdb", size: 125)] | "{\"deviceMapping\":\"ami\"}"     // Even though blockDevices set, Prefer AMI Block Device Mappings overrides, set deviceMapping as 'ami'
+    false                         | [new AmazonBlockDevice(deviceName: "/dev/sdb", size: 125)] | "{\"deviceMapping\":\"custom\"}"  // blockDevices set, set deviceMapping as 'custom'
+    false                         | null                                                       | "{\"deviceMapping\":\"default\"}" // blockDevices not set, set deviceMapping as 'default'
+  }
+
   void "should send instance class block devices to AutoScalingWorker when matched and none are specified"() {
     setup:
     def deployCallCounts = 0


### PR DESCRIPTION
Added deploymentMetadata tag to specify the deviceMapping used when specifying the block devices schema to use.

Already existing unit tests involving Block Devices Mappings seem to indicate that blockDevices == null as being the indication that the BlockDeviceConfig was used, so there didn't seem a need to parse blockDevices to see if it matched what BlockDeviceConfig would specify for that instanceType.